### PR TITLE
nvim: Enable formatting on save for ESLint

### DIFF
--- a/nvim/lua/plugins/lsp/init.lua
+++ b/nvim/lua/plugins/lsp/init.lua
@@ -64,7 +64,14 @@ return {
             },
           },
         },
-        "eslint",
+        eslint = {
+          on_attach = function(client, bufnr)
+            vim.api.nvim_create_autocmd("BufWritePre", {
+              buffer = bufnr,
+              command = "EslintFixAll",
+            })
+          end,
+        },
         "html",
         "cssls",
         "pyright",


### PR DESCRIPTION
This change will run "EslintFixAll" to format JS files on save.